### PR TITLE
fix for unace

### DIFF
--- a/src/zipjail/zipjail.c
+++ b/src/zipjail/zipjail.c
@@ -51,7 +51,7 @@ static const char *g_syscall_allowed[] = {
     "exit_group", "fchmod", "utime", "getdents", "chmod", "munmap", "time",
     "rt_sigaction", "brk", "fcntl", "access", "getcwd", "chdir", "select",
     "newfstatat", "fstat64", "_llseek", "gettimeofday", "stat64",
-    "getdents64", "getpid", "fchown", "rt_sigprocmask", NULL,
+    "getdents64", "getpid", "fchown", "rt_sigprocmask", "pselect6", NULL,
 };
 
 static const char *g_openat_allowed[] = {


### PR DESCRIPTION
Working: Reading archive. Please wait. Blocked system call occurred during sandboxing! ip=0x7f0382c1274d sp=0x7ffeb9b97010 abi=0 nr=270 syscall=pselect6

test file https://github.com/CAPESandbox/sflock/blob/master/tests/files/ace_plain.ace